### PR TITLE
Replace email alarm notifications with Slack via AWS Chatbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# CLAUDE
+CLAUDE.local.md

--- a/infrastructure/config/environment.ts
+++ b/infrastructure/config/environment.ts
@@ -41,12 +41,30 @@ export interface EnvironmentConfig {
   monitoring: {
     enableXRay: boolean;
     logRetentionDays: number;
-    alarmEmail?: string;
+    slack?: {
+      workspaceId: string;
+      channelId: string;
+    };
   };
 }
 
 export const getEnvironmentConfig = (environment: string): EnvironmentConfig => {
   const env = environment || 'development';
+
+  const slackWorkspaceId = process.env.SLACK_WORKSPACE_ID;
+  const slackChannelIdByEnv: Record<string, string | undefined> = {
+    development: process.env.SLACK_CHANNEL_ID_DEV,
+    staging: process.env.SLACK_CHANNEL_ID_STAGING,
+    production: process.env.SLACK_CHANNEL_ID_PROD,
+  };
+
+  const buildSlackConfig = (envName: string) => {
+    const channelId = slackChannelIdByEnv[envName];
+    if (slackWorkspaceId && channelId) {
+      return { workspaceId: slackWorkspaceId, channelId };
+    }
+    return undefined;
+  };
 
   const configs: Record<string, EnvironmentConfig> = {
     development: {
@@ -85,6 +103,7 @@ export const getEnvironmentConfig = (environment: string): EnvironmentConfig => 
       monitoring: {
         enableXRay: true,
         logRetentionDays: 7,
+        slack: buildSlackConfig('development'),
       },
     },
 
@@ -124,6 +143,7 @@ export const getEnvironmentConfig = (environment: string): EnvironmentConfig => 
       monitoring: {
         enableXRay: true,
         logRetentionDays: 14,
+        slack: buildSlackConfig('staging'),
       },
     },
 
@@ -163,7 +183,7 @@ export const getEnvironmentConfig = (environment: string): EnvironmentConfig => 
       monitoring: {
         enableXRay: true,
         logRetentionDays: 30,
-        alarmEmail: 'alerts@readafull.com',
+        slack: buildSlackConfig('production'),
       },
     },
   };

--- a/infrastructure/lib/monitoring-stack.ts
+++ b/infrastructure/lib/monitoring-stack.ts
@@ -2,7 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as cloudwatch_actions from 'aws-cdk-lib/aws-cloudwatch-actions';
 import * as sns from 'aws-cdk-lib/aws-sns';
-import * as sns_subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as chatbot from 'aws-cdk-lib/aws-chatbot';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
@@ -33,11 +33,14 @@ export class MonitoringStack extends cdk.Stack {
       displayName: `Readafull ${config.environment} Alarms`,
     });
 
-    // Subscribe email to alarm topic if provided
-    if (config.monitoring.alarmEmail) {
-      this.alarmTopic.addSubscription(
-        new sns_subscriptions.EmailSubscription(config.monitoring.alarmEmail)
-      );
+    // Route alarms to Slack via AWS Chatbot if configured
+    if (config.monitoring.slack) {
+      new chatbot.SlackChannelConfiguration(this, 'SlackChannel', {
+        slackChannelConfigurationName: `${config.stackPrefix}-slack-alerts`,
+        slackWorkspaceId: config.monitoring.slack.workspaceId,
+        slackChannelId: config.monitoring.slack.channelId,
+        notificationTopics: [this.alarmTopic],
+      });
     }
 
     // Create CloudWatch Dashboard


### PR DESCRIPTION
## Summary
- Remove the unreachable `alerts@readafull.com` email subscription that would have left an SNS subscription stuck in `PendingConfirmation` and dropped every alarm notification in production.
- Route CloudWatch alarms to per-environment Slack channels using `aws-chatbot.SlackChannelConfiguration`, which keeps notifications free across dev/staging/prod and avoids adding another Lambda + its alarms.
- Read Slack workspace and channel IDs from environment variables (`SLACK_WORKSPACE_ID`, `SLACK_CHANNEL_ID_{DEV,STAGING,PROD}`) so they stay out of source. The Chatbot construct is only created when both values are present, so unconfigured environments deploy cleanly with no notification destination.

## Manual setup required before first deploy
1. Authorize the AWS Chatbot app in the Slack workspace (Slack App Directory → Add to Slack).
2. In AWS Console → Chatbot, complete the workspace OAuth handshake to obtain the `T...` workspace ID.
3. `/invite @aws` the bot into each environment's destination channel and copy each `C...` channel ID.
4. Export the env vars before `npm run cdk:deploy:<env>`.

## Test plan
- [x] `npm run build` passes
- [x] `cdk synth` with no Slack env vars → 0 `AWS::Chatbot::SlackChannelConfiguration` resources, 0 leftover `AWS::SNS::Subscription` resources
- [x] `cdk synth` with dummy `SLACK_WORKSPACE_ID=T12345678` / `SLACK_CHANNEL_ID_DEV=C87654321` → 1 Chatbot config wired to the alarm SNS topic
- [ ] Post-deploy: trigger a test alarm and confirm a message lands in the dev Slack channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)