### PR TITLE
feat(data): DynamoDB single-table data access layer (Task 3)

### DIFF
--- a/.kiro/specs/readafull-mvp/tasks.md
+++ b/.kiro/specs/readafull-mvp/tasks.md
@@ -13,7 +13,7 @@
   - Write unit tests for social authentication flows
   - _Requirements: 7.1, 7.2, 7.3, 7.4_
 
-- [ ] 3. Create DynamoDB data layer with single-table design
+- [x] 3. Create DynamoDB data layer with single-table design
   - Design and implement DynamoDB table schema with GSI for access patterns
   - Create DynamoDB service layer with CRUD operations for users, texts, and audio sessions
   - Implement data access patterns for user-specific content retrieval

--- a/infrastructure/lambda/shared/dynamoService.ts
+++ b/infrastructure/lambda/shared/dynamoService.ts
@@ -1,0 +1,371 @@
+/**
+ * DynamoDB data-access layer for the Readafull single-table design.
+ *
+ * Wraps the low-level Document Client with typed CRUD operations and the
+ * user-specific access patterns documented in design_aws.md. Lambda handlers
+ * should depend on this service rather than issuing raw DynamoDB commands so the
+ * key scheme and marshalling stay in one place.
+ */
+import { randomUUID } from 'crypto';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  AudioSession,
+  CreateAudioSessionInput,
+  CreateTextInput,
+  DEFAULT_USER_PREFERENCES,
+  EntityType,
+  TextContent,
+  UserPreferences,
+  UserProfile,
+} from './types';
+import {
+  AUDIO_SK_PREFIX,
+  TEXT_SK_PREFIX,
+  audioSk,
+  createdGsiSk,
+  difficultyGsiPk,
+  profileSk,
+  textSk,
+  userPk,
+} from './keys';
+
+let cachedClient: DynamoDBDocumentClient | undefined;
+
+const getDefaultClient = (): DynamoDBDocumentClient => {
+  if (!cachedClient) {
+    const region = process.env.AWS_REGION ?? 'ap-northeast-1';
+    cachedClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
+      marshallOptions: { removeUndefinedValues: true },
+    });
+  }
+  return cachedClient;
+};
+
+/** Strip the internal key attributes, returning the plain domain object. */
+const stripKeys = <T>(item: Record<string, unknown>): T => {
+  const { PK, SK, GSI1PK, GSI1SK, entityType, ...rest } = item;
+  return rest as T;
+};
+
+export interface DynamoServiceOptions {
+  tableName?: string;
+  client?: DynamoDBDocumentClient;
+}
+
+export class DynamoService {
+  private readonly client: DynamoDBDocumentClient;
+  private readonly tableName: string;
+
+  constructor(options: DynamoServiceOptions = {}) {
+    this.client = options.client ?? getDefaultClient();
+    const tableName = options.tableName ?? process.env.MAIN_TABLE_NAME;
+    if (!tableName) {
+      throw new Error('MAIN_TABLE_NAME environment variable is not configured');
+    }
+    this.tableName = tableName;
+  }
+
+  // ---------------------------------------------------------------------------
+  // User profile
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a user profile. Idempotent: a second create for the same user is a
+   * no-op (returns false) thanks to the attribute_not_exists condition.
+   */
+  async createUserProfile(profile: UserProfile): Promise<boolean> {
+    try {
+      await this.client.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: {
+            PK: userPk(profile.userId),
+            SK: profileSk(),
+            entityType: 'USER' satisfies EntityType,
+            ...profile,
+          },
+          ConditionExpression: 'attribute_not_exists(PK)',
+        })
+      );
+      return true;
+    } catch (error) {
+      if ((error as { name?: string }).name === 'ConditionalCheckFailedException') {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async getUserProfile(userId: string): Promise<UserProfile | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: profileSk() },
+      })
+    );
+    return result.Item ? stripKeys<UserProfile>(result.Item) : null;
+  }
+
+  /** Replace the user's preferences and return the updated profile. */
+  async updateUserPreferences(
+    userId: string,
+    preferences: UserPreferences
+  ): Promise<UserProfile> {
+    const result = await this.client.send(
+      new UpdateCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: profileSk() },
+        UpdateExpression: 'SET preferences = :prefs',
+        ConditionExpression: 'attribute_exists(PK)',
+        ExpressionAttributeValues: { ':prefs': preferences },
+        ReturnValues: 'ALL_NEW',
+      })
+    );
+    return stripKeys<UserProfile>(result.Attributes ?? {});
+  }
+
+  /** Touch the lastLoginAt timestamp on sign-in. */
+  async updateLastLogin(
+    userId: string,
+    timestamp: string = new Date().toISOString()
+  ): Promise<void> {
+    await this.client.send(
+      new UpdateCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: profileSk() },
+        UpdateExpression: 'SET lastLoginAt = :ts',
+        ConditionExpression: 'attribute_exists(PK)',
+        ExpressionAttributeValues: { ':ts': timestamp },
+      })
+    );
+  }
+
+  async deleteUserProfile(userId: string): Promise<void> {
+    await this.client.send(
+      new DeleteCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: profileSk() },
+      })
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Text content
+  // ---------------------------------------------------------------------------
+
+  /** Persist a generated text, generating the id and timestamps. */
+  async saveText(input: CreateTextInput): Promise<TextContent> {
+    const now = new Date().toISOString();
+    const text: TextContent = {
+      ...input,
+      textId: input.textId ?? randomUUID(),
+      createdAt: now,
+      lastAccessedAt: now,
+    };
+
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: {
+          PK: userPk(text.userId),
+          SK: textSk(text.textId),
+          GSI1PK: difficultyGsiPk(text.difficulty),
+          GSI1SK: createdGsiSk(text.createdAt),
+          entityType: 'TEXT' satisfies EntityType,
+          ...text,
+        },
+      })
+    );
+
+    return text;
+  }
+
+  async getText(userId: string, textId: string): Promise<TextContent | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: textSk(textId) },
+      })
+    );
+    return result.Item ? stripKeys<TextContent>(result.Item) : null;
+  }
+
+  /**
+   * List a user's saved texts, newest first. Texts share a partition, so this
+   * is a single Query against PK with a SK begins_with filter.
+   */
+  async listUserTexts(
+    userId: string,
+    options: { limit?: number } = {}
+  ): Promise<TextContent[]> {
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+        ExpressionAttributeValues: {
+          ':pk': userPk(userId),
+          ':prefix': TEXT_SK_PREFIX,
+        },
+        ScanIndexForward: false,
+        Limit: options.limit,
+      })
+    );
+    return (result.Items ?? []).map((item) => stripKeys<TextContent>(item));
+  }
+
+  /**
+   * List texts of a given difficulty across all users, newest first, via GSI1.
+   * Used to surface previously generated content for reuse.
+   */
+  async listTextsByDifficulty(
+    difficulty: string,
+    options: { limit?: number } = {}
+  ): Promise<TextContent[]> {
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        IndexName: 'GSI1',
+        KeyConditionExpression: 'GSI1PK = :pk',
+        ExpressionAttributeValues: {
+          ':pk': difficultyGsiPk(difficulty),
+        },
+        ScanIndexForward: false,
+        Limit: options.limit,
+      })
+    );
+    return (result.Items ?? []).map((item) => stripKeys<TextContent>(item));
+  }
+
+  /** Record that a text was opened, for recency-based sorting in the UI. */
+  async touchText(
+    userId: string,
+    textId: string,
+    timestamp: string = new Date().toISOString()
+  ): Promise<void> {
+    await this.client.send(
+      new UpdateCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: textSk(textId) },
+        UpdateExpression: 'SET lastAccessedAt = :ts',
+        ConditionExpression: 'attribute_exists(PK)',
+        ExpressionAttributeValues: { ':ts': timestamp },
+      })
+    );
+  }
+
+  async deleteText(userId: string, textId: string): Promise<void> {
+    await this.client.send(
+      new DeleteCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: textSk(textId) },
+      })
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Audio sessions
+  // ---------------------------------------------------------------------------
+
+  async saveAudioSession(
+    input: CreateAudioSessionInput
+  ): Promise<AudioSession> {
+    const session: AudioSession = {
+      ...input,
+      sessionId: input.sessionId ?? randomUUID(),
+      playbackCount: input.playbackCount ?? 0,
+      createdAt: new Date().toISOString(),
+    };
+
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: {
+          PK: userPk(session.userId),
+          SK: audioSk(session.sessionId),
+          entityType: 'AUDIO' satisfies EntityType,
+          ...session,
+        },
+      })
+    );
+
+    return session;
+  }
+
+  async getAudioSession(
+    userId: string,
+    sessionId: string
+  ): Promise<AudioSession | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: audioSk(sessionId) },
+      })
+    );
+    return result.Item ? stripKeys<AudioSession>(result.Item) : null;
+  }
+
+  async listUserAudioSessions(
+    userId: string,
+    options: { limit?: number } = {}
+  ): Promise<AudioSession[]> {
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+        ExpressionAttributeValues: {
+          ':pk': userPk(userId),
+          ':prefix': AUDIO_SK_PREFIX,
+        },
+        ScanIndexForward: false,
+        Limit: options.limit,
+      })
+    );
+    return (result.Items ?? []).map((item) => stripKeys<AudioSession>(item));
+  }
+
+  /** Atomically increment playbackCount and return the new value. */
+  async incrementPlaybackCount(
+    userId: string,
+    sessionId: string
+  ): Promise<number> {
+    const result = await this.client.send(
+      new UpdateCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: audioSk(sessionId) },
+        UpdateExpression:
+          'SET playbackCount = if_not_exists(playbackCount, :zero) + :one',
+        ConditionExpression: 'attribute_exists(PK)',
+        ExpressionAttributeValues: { ':zero': 0, ':one': 1 },
+        ReturnValues: 'UPDATED_NEW',
+      })
+    );
+    return (result.Attributes?.playbackCount as number) ?? 0;
+  }
+
+  async deleteAudioSession(userId: string, sessionId: string): Promise<void> {
+    await this.client.send(
+      new DeleteCommand({
+        TableName: this.tableName,
+        Key: { PK: userPk(userId), SK: audioSk(sessionId) },
+      })
+    );
+  }
+}
+
+/** Shared default instance for Lambda handlers (lazily constructed). */
+let defaultService: DynamoService | undefined;
+
+export const getDynamoService = (): DynamoService => {
+  if (!defaultService) {
+    defaultService = new DynamoService();
+  }
+  return defaultService;
+};

--- a/infrastructure/lambda/shared/index.ts
+++ b/infrastructure/lambda/shared/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './keys';
+export * from './dynamoService';

--- a/infrastructure/lambda/shared/keys.ts
+++ b/infrastructure/lambda/shared/keys.ts
@@ -1,0 +1,31 @@
+/**
+ * Key builders for the single-table design.
+ *
+ * Centralising key construction keeps the PK/SK conventions in one place so the
+ * service layer and any future consumers never hand-craft key strings. The
+ * scheme matches the access patterns documented in design_aws.md:
+ *
+ *   1. User profile:        PK = USER#<userId>,  SK = PROFILE#main
+ *   2. User texts:          PK = USER#<userId>,  SK begins_with TEXT#
+ *   3. User audio sessions: PK = USER#<userId>,  SK begins_with AUDIO#
+ *   4. Texts by difficulty: GSI1PK = DIFFICULTY#<level>, GSI1SK = CREATED#<ts>
+ */
+
+export const PROFILE_SK = 'PROFILE#main';
+export const TEXT_SK_PREFIX = 'TEXT#';
+export const AUDIO_SK_PREFIX = 'AUDIO#';
+
+export const userPk = (userId: string): string => `USER#${userId}`;
+
+export const profileSk = (): string => PROFILE_SK;
+
+export const textSk = (textId: string): string => `${TEXT_SK_PREFIX}${textId}`;
+
+export const audioSk = (sessionId: string): string =>
+  `${AUDIO_SK_PREFIX}${sessionId}`;
+
+export const difficultyGsiPk = (difficulty: string): string =>
+  `DIFFICULTY#${difficulty}`;
+
+export const createdGsiSk = (timestamp: string): string =>
+  `CREATED#${timestamp}`;

--- a/infrastructure/lambda/shared/types.ts
+++ b/infrastructure/lambda/shared/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Domain types for the Readafull single-table data model.
+ *
+ * Every record lives in one DynamoDB table (see StorageStack) keyed by PK/SK
+ * with a single GSI (GSI1) for difficulty-based lookups. The `*Item` interfaces
+ * describe the marshalled shape stored in DynamoDB; the plain domain interfaces
+ * describe what callers work with.
+ */
+
+export type DifficultyLevel = 'beginner' | 'intermediate' | 'advanced';
+
+export type AudioQuality = 'low' | 'medium' | 'high';
+
+export type EntityType = 'USER' | 'TEXT' | 'AUDIO';
+
+export interface UserPreferences {
+  defaultDifficulty: DifficultyLevel;
+  showTranslationByDefault: boolean;
+  audioQuality: AudioQuality;
+  autoPlayTTS: boolean;
+}
+
+export const DEFAULT_USER_PREFERENCES: UserPreferences = {
+  defaultDifficulty: 'beginner',
+  showTranslationByDefault: true,
+  audioQuality: 'medium',
+  autoPlayTTS: false,
+};
+
+/** A user profile created on first social sign-in. */
+export interface UserProfile {
+  userId: string;
+  email: string | null;
+  name: string;
+  profilePicture: string | null;
+  provider: string;
+  preferences: UserPreferences;
+  createdAt: string;
+  lastLoginAt: string;
+}
+
+/** An AI-generated reading passage with its Japanese translation. */
+export interface TextContent {
+  userId: string;
+  textId: string;
+  englishText: string;
+  japaneseTranslation: string;
+  difficulty: DifficultyLevel;
+  topic?: string;
+  wordCount: number;
+  createdAt: string;
+  lastAccessedAt: string;
+}
+
+/** A recording or TTS playback session tied to a text. */
+export interface AudioSession {
+  userId: string;
+  sessionId: string;
+  textId: string;
+  s3Key: string;
+  duration: number;
+  playbackCount: number;
+  createdAt: string;
+}
+
+/** Fields callers supply when creating a text; ids/timestamps are generated. */
+export type CreateTextInput = Omit<
+  TextContent,
+  'textId' | 'createdAt' | 'lastAccessedAt'
+> & {
+  textId?: string;
+};
+
+/** Fields callers supply when creating an audio session. */
+export type CreateAudioSessionInput = Omit<
+  AudioSession,
+  'sessionId' | 'playbackCount' | 'createdAt'
+> & {
+  sessionId?: string;
+  playbackCount?: number;
+};

--- a/infrastructure/test/dynamo-service.test.ts
+++ b/infrastructure/test/dynamo-service.test.ts
@@ -1,0 +1,352 @@
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  DynamoService,
+  UserProfile,
+  DEFAULT_USER_PREFERENCES,
+} from '../lambda/shared';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+const TABLE = 'readafull-main-table-test';
+
+const buildService = () => new DynamoService({ tableName: TABLE });
+
+const sampleProfile: UserProfile = {
+  userId: 'user-1',
+  email: 'user@example.com',
+  name: 'Test User',
+  profilePicture: null,
+  provider: 'google',
+  preferences: DEFAULT_USER_PREFERENCES,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastLoginAt: '2026-01-01T00:00:00.000Z',
+};
+
+const lastInput = (command: any) => {
+  const calls = ddbMock.commandCalls(command);
+  return calls[calls.length - 1].args[0].input;
+};
+
+describe('DynamoService', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+
+  describe('construction', () => {
+    it('throws when no table name is provided and env is unset', () => {
+      const original = process.env.MAIN_TABLE_NAME;
+      delete process.env.MAIN_TABLE_NAME;
+      expect(() => new DynamoService()).toThrow(/MAIN_TABLE_NAME/);
+      if (original !== undefined) process.env.MAIN_TABLE_NAME = original;
+    });
+
+    it('reads the table name from MAIN_TABLE_NAME when not passed', () => {
+      process.env.MAIN_TABLE_NAME = 'env-table';
+      ddbMock.on(GetCommand).resolves({});
+      expect(() => new DynamoService()).not.toThrow();
+      delete process.env.MAIN_TABLE_NAME;
+    });
+  });
+
+  describe('user profile', () => {
+    it('creates a profile with USER keys and entityType', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const created = await buildService().createUserProfile(sampleProfile);
+
+      expect(created).toBe(true);
+      const input = lastInput(PutCommand);
+      expect(input.TableName).toBe(TABLE);
+      expect(input.ConditionExpression).toBe('attribute_not_exists(PK)');
+      expect(input.Item).toMatchObject({
+        PK: 'USER#user-1',
+        SK: 'PROFILE#main',
+        entityType: 'USER',
+        userId: 'user-1',
+        provider: 'google',
+        preferences: DEFAULT_USER_PREFERENCES,
+      });
+    });
+
+    it('returns false when the profile already exists (idempotent create)', async () => {
+      ddbMock.on(PutCommand).rejects(
+        Object.assign(new Error('exists'), {
+          name: 'ConditionalCheckFailedException',
+        })
+      );
+
+      await expect(
+        buildService().createUserProfile(sampleProfile)
+      ).resolves.toBe(false);
+    });
+
+    it('rethrows unexpected errors on create', async () => {
+      ddbMock.on(PutCommand).rejects(new Error('throttled'));
+      await expect(
+        buildService().createUserProfile(sampleProfile)
+      ).rejects.toThrow('throttled');
+    });
+
+    it('gets a profile and strips internal key attributes', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          PK: 'USER#user-1',
+          SK: 'PROFILE#main',
+          entityType: 'USER',
+          ...sampleProfile,
+        },
+      });
+
+      const profile = await buildService().getUserProfile('user-1');
+
+      expect(profile).toEqual(sampleProfile);
+      expect(profile).not.toHaveProperty('PK');
+      expect(profile).not.toHaveProperty('entityType');
+      expect(lastInput(GetCommand).Key).toEqual({
+        PK: 'USER#user-1',
+        SK: 'PROFILE#main',
+      });
+    });
+
+    it('returns null when the profile is not found', async () => {
+      ddbMock.on(GetCommand).resolves({});
+      await expect(buildService().getUserProfile('missing')).resolves.toBeNull();
+    });
+
+    it('updates preferences guarded by attribute_exists', async () => {
+      const newPrefs = { ...DEFAULT_USER_PREFERENCES, autoPlayTTS: true };
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: {
+          PK: 'USER#user-1',
+          SK: 'PROFILE#main',
+          ...sampleProfile,
+          preferences: newPrefs,
+        },
+      });
+
+      const updated = await buildService().updateUserPreferences(
+        'user-1',
+        newPrefs
+      );
+
+      expect(updated.preferences).toEqual(newPrefs);
+      const input = lastInput(UpdateCommand);
+      expect(input.ConditionExpression).toBe('attribute_exists(PK)');
+      expect(input.ExpressionAttributeValues[':prefs']).toEqual(newPrefs);
+      expect(input.ReturnValues).toBe('ALL_NEW');
+    });
+
+    it('updates the last login timestamp', async () => {
+      ddbMock.on(UpdateCommand).resolves({});
+      await buildService().updateLastLogin('user-1', '2026-06-20T00:00:00.000Z');
+
+      const input = lastInput(UpdateCommand);
+      expect(input.UpdateExpression).toBe('SET lastLoginAt = :ts');
+      expect(input.ExpressionAttributeValues[':ts']).toBe(
+        '2026-06-20T00:00:00.000Z'
+      );
+    });
+
+    it('deletes a profile by key', async () => {
+      ddbMock.on(DeleteCommand).resolves({});
+      await buildService().deleteUserProfile('user-1');
+      expect(lastInput(DeleteCommand).Key).toEqual({
+        PK: 'USER#user-1',
+        SK: 'PROFILE#main',
+      });
+    });
+  });
+
+  describe('text content', () => {
+    const textInput = {
+      userId: 'user-1',
+      englishText: 'Hello world.',
+      japaneseTranslation: 'こんにちは世界。',
+      difficulty: 'beginner' as const,
+      topic: 'greetings',
+      wordCount: 2,
+    };
+
+    it('saves a text generating id, timestamps and GSI keys', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const saved = await buildService().saveText(textInput);
+
+      expect(saved.textId).toMatch(/[0-9a-f-]{36}/);
+      expect(saved.createdAt).toBe(saved.lastAccessedAt);
+
+      const input = lastInput(PutCommand);
+      expect(input.Item).toMatchObject({
+        PK: 'USER#user-1',
+        SK: `TEXT#${saved.textId}`,
+        GSI1PK: 'DIFFICULTY#beginner',
+        GSI1SK: `CREATED#${saved.createdAt}`,
+        entityType: 'TEXT',
+        englishText: 'Hello world.',
+      });
+    });
+
+    it('honours a caller-supplied textId', async () => {
+      ddbMock.on(PutCommand).resolves({});
+      const saved = await buildService().saveText({
+        ...textInput,
+        textId: 'fixed-id',
+      });
+      expect(saved.textId).toBe('fixed-id');
+      expect(lastInput(PutCommand).Item.SK).toBe('TEXT#fixed-id');
+    });
+
+    it('gets a text by user and id', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          PK: 'USER#user-1',
+          SK: 'TEXT#t1',
+          GSI1PK: 'DIFFICULTY#beginner',
+          GSI1SK: 'CREATED#2026-01-01T00:00:00.000Z',
+          entityType: 'TEXT',
+          userId: 'user-1',
+          textId: 't1',
+          englishText: 'Hi.',
+        },
+      });
+
+      const text = await buildService().getText('user-1', 't1');
+      expect(text).toMatchObject({ textId: 't1', englishText: 'Hi.' });
+      expect(text).not.toHaveProperty('GSI1PK');
+    });
+
+    it('lists user texts newest-first using begins_with on SK', async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          { PK: 'USER#user-1', SK: 'TEXT#t2', textId: 't2', entityType: 'TEXT' },
+          { PK: 'USER#user-1', SK: 'TEXT#t1', textId: 't1', entityType: 'TEXT' },
+        ],
+      });
+
+      const texts = await buildService().listUserTexts('user-1', { limit: 10 });
+
+      expect(texts).toHaveLength(2);
+      const input = lastInput(QueryCommand);
+      expect(input.KeyConditionExpression).toBe(
+        'PK = :pk AND begins_with(SK, :prefix)'
+      );
+      expect(input.ExpressionAttributeValues).toEqual({
+        ':pk': 'USER#user-1',
+        ':prefix': 'TEXT#',
+      });
+      expect(input.ScanIndexForward).toBe(false);
+      expect(input.Limit).toBe(10);
+    });
+
+    it('lists texts by difficulty via GSI1', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+      await buildService().listTextsByDifficulty('intermediate');
+
+      const input = lastInput(QueryCommand);
+      expect(input.IndexName).toBe('GSI1');
+      expect(input.KeyConditionExpression).toBe('GSI1PK = :pk');
+      expect(input.ExpressionAttributeValues[':pk']).toBe(
+        'DIFFICULTY#intermediate'
+      );
+    });
+
+    it('touches lastAccessedAt', async () => {
+      ddbMock.on(UpdateCommand).resolves({});
+      await buildService().touchText('user-1', 't1', '2026-06-20T12:00:00.000Z');
+
+      const input = lastInput(UpdateCommand);
+      expect(input.UpdateExpression).toBe('SET lastAccessedAt = :ts');
+      expect(input.Key).toEqual({ PK: 'USER#user-1', SK: 'TEXT#t1' });
+    });
+
+    it('deletes a text by key', async () => {
+      ddbMock.on(DeleteCommand).resolves({});
+      await buildService().deleteText('user-1', 't1');
+      expect(lastInput(DeleteCommand).Key).toEqual({
+        PK: 'USER#user-1',
+        SK: 'TEXT#t1',
+      });
+    });
+  });
+
+  describe('audio sessions', () => {
+    const audioInput = {
+      userId: 'user-1',
+      textId: 't1',
+      s3Key: 'recordings/user-1/clip.mp3',
+      duration: 12,
+    };
+
+    it('saves an audio session defaulting playbackCount to 0', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const saved = await buildService().saveAudioSession(audioInput);
+
+      expect(saved.sessionId).toMatch(/[0-9a-f-]{36}/);
+      expect(saved.playbackCount).toBe(0);
+      const input = lastInput(PutCommand);
+      expect(input.Item).toMatchObject({
+        PK: 'USER#user-1',
+        SK: `AUDIO#${saved.sessionId}`,
+        entityType: 'AUDIO',
+        textId: 't1',
+        playbackCount: 0,
+      });
+    });
+
+    it('gets an audio session', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          PK: 'USER#user-1',
+          SK: 'AUDIO#s1',
+          entityType: 'AUDIO',
+          userId: 'user-1',
+          sessionId: 's1',
+        },
+      });
+      const session = await buildService().getAudioSession('user-1', 's1');
+      expect(session).toMatchObject({ sessionId: 's1' });
+    });
+
+    it('lists user audio sessions with begins_with AUDIO#', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+      await buildService().listUserAudioSessions('user-1');
+
+      const input = lastInput(QueryCommand);
+      expect(input.ExpressionAttributeValues[':prefix']).toBe('AUDIO#');
+      expect(input.ScanIndexForward).toBe(false);
+    });
+
+    it('increments playback count atomically and returns new value', async () => {
+      ddbMock.on(UpdateCommand).resolves({ Attributes: { playbackCount: 3 } });
+
+      const count = await buildService().incrementPlaybackCount('user-1', 's1');
+
+      expect(count).toBe(3);
+      const input = lastInput(UpdateCommand);
+      expect(input.UpdateExpression).toBe(
+        'SET playbackCount = if_not_exists(playbackCount, :zero) + :one'
+      );
+      expect(input.ExpressionAttributeValues).toEqual({ ':zero': 0, ':one': 1 });
+      expect(input.ReturnValues).toBe('UPDATED_NEW');
+    });
+
+    it('deletes an audio session by key', async () => {
+      ddbMock.on(DeleteCommand).resolves({});
+      await buildService().deleteAudioSession('user-1', 's1');
+      expect(lastInput(DeleteCommand).Key).toEqual({
+        PK: 'USER#user-1',
+        SK: 'AUDIO#s1',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Task 3 — Create DynamoDB data layer with single-table design**.

The DynamoDB table itself (single-table + `GSI1`) already exists in `StorageStack` from Task 1, so this PR adds the **shared data access layer** that Lambda functions (Tasks 4–7) will depend on, plus unit tests.

## Changes

- `lambda/shared/types.ts` — `UserProfile` / `TextContent` / `AudioSession` domain types, preferences, difficulty/quality unions, and `DEFAULT_USER_PREFERENCES`
- `lambda/shared/keys.ts` — centralised PK/SK/GSI key builders matching the access patterns in `design_aws.md`
- `lambda/shared/dynamoService.ts` — `DynamoService` class:
  - **User**: create (idempotent via `attribute_not_exists`), get, updatePreferences, updateLastLogin, delete
  - **Text**: save (auto UUID + timestamps + GSI keys), get, `listUserTexts` (PK + `begins_with TEXT#`, newest-first), `listTextsByDifficulty` (GSI1), touch, delete
  - **Audio**: save, get, `listUserAudioSessions`, atomic `incrementPlaybackCount`, delete
- `lambda/shared/index.ts` — barrel export
- `test/dynamo-service.test.ts` — 22 unit tests

## Access patterns covered

1. User profile — `PK=USER#<id>`, `SK=PROFILE#main`
2. User texts — `PK=USER#<id>`, `SK begins_with TEXT#`
3. User audio — `PK=USER#<id>`, `SK begins_with AUDIO#`
4. Texts by difficulty — `GSI1PK=DIFFICULTY#<level>`, `GSI1SK=CREATED#<ts>`

Consistent with the existing `postConfirmation` trigger key scheme and `entityType` convention; existing code is left untouched.

## Test results

- `tsc --noEmit`: clean
- `jest`: **51 passed / 4 suites** (22 new, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)